### PR TITLE
Add support for ${workspaceFolder} in settings

### DIFF
--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -15,6 +15,7 @@
 import * as child_process from "child_process";
 import * as path from "path";
 import * as vscode from "vscode";
+import { resolvePath } from "../common/util";
 import { IBuildifierResult, IBuildifierWarning } from "./buildifier_result";
 
 /** Whether to warn about lint findings or fix them. */
@@ -166,18 +167,12 @@ export function getDefaultBuildifierExecutablePath(): string {
   // Try to retrieve the executable from VS Code's settings. If it's not set,
   // just use "buildifier" as the default and get it from the system PATH.
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  let buildifierExecutable = bazelConfig.get<string>("buildifierExecutable");
+  const buildifierExecutable = bazelConfig.get<string>("buildifierExecutable");
   if (buildifierExecutable.length === 0) {
     return "buildifier";
   }
 
-  if (vscode.workspace.workspaceFolders !== undefined) {
-      const wspath = vscode.workspace.workspaceFolders[0].uri.path;
-      buildifierExecutable = buildifierExecutable.replace(
-        "${workspaceFolder}", wspath);
-  }
-
-  return buildifierExecutable;
+  return resolvePath(buildifierExecutable);
 }
 
 /**

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -166,10 +166,17 @@ export function getDefaultBuildifierExecutablePath(): string {
   // Try to retrieve the executable from VS Code's settings. If it's not set,
   // just use "buildifier" as the default and get it from the system PATH.
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  const buildifierExecutable = bazelConfig.get<string>("buildifierExecutable");
+  let buildifierExecutable = bazelConfig.get<string>("buildifierExecutable");
   if (buildifierExecutable.length === 0) {
     return "buildifier";
   }
+
+  if (vscode.workspace.workspaceFolders !== undefined) {
+      const wspath = vscode.workspace.workspaceFolders[0].uri.path;
+      buildifierExecutable = buildifierExecutable.replace(
+        "${workspaceFolder}", wspath);
+  }
+
   return buildifierExecutable;
 }
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,0 +1,55 @@
+"use strict";
+
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+
+// Borrowed from https://github.com/golang/vscode-go
+
+/**
+ * Expands ~ to homedir in non-Windows platform
+ */
+export function resolveHomeDir(inputPath: string): string {
+    if (!inputPath || !inputPath.trim()) {
+        return inputPath;
+    }
+    return inputPath.startsWith('~') ? path.join(os.homedir(), inputPath.substr(1)) : inputPath;
+}
+
+export function getWorkspaceFolderPath(fileUri?: vscode.Uri): string | undefined {
+    if (fileUri) {
+        const workspace = vscode.workspace.getWorkspaceFolder(fileUri);
+        if (workspace) {
+            return workspace.uri.fsPath;
+        }
+    }
+
+    // fall back to the first workspace
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length) {
+        return folders[0].uri.fsPath;
+    }
+    return undefined;
+}
+
+/**
+ * Expands ~ to homedir in non-Windows platform and resolves
+ * ${workspaceFolder}, ${workspaceRoot} and ${workspaceFolderBasename}
+ */
+export function resolvePath(inputPath: string, workspaceFolder?: string): string {
+    if (!inputPath || !inputPath.trim()) {
+        return inputPath;
+    }
+
+    if (!workspaceFolder && vscode.workspace.workspaceFolders) {
+        workspaceFolder = getWorkspaceFolderPath(
+            vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.uri
+        );
+    }
+
+    if (workspaceFolder) {
+        inputPath = inputPath.replace(/\${workspaceFolder}|\${workspaceRoot}/g, workspaceFolder);
+        inputPath = inputPath.replace(/\${workspaceFolderBasename}/g, path.basename(workspaceFolder));
+    }
+    return resolveHomeDir(inputPath);
+}

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as vscode from "vscode";
+import { resolvePath } from "../common/util";
 
 /**
  * Gets the path to the Bazel executable specified by the workspace
@@ -26,14 +27,9 @@ export function getDefaultBazelExecutablePath(): string {
   // Try to retrieve the executable from VS Code's settings. If it's not set,
   // just use "bazel" as the default and get it from the system PATH.
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  let bazelExecutable = bazelConfig.get<string>("executable");
+  const bazelExecutable = bazelConfig.get<string>("executable");
   if (bazelExecutable.length === 0) {
     return "bazel";
   }
-  if (vscode.workspace.workspaceFolders !== undefined) {
-      const wspath = vscode.workspace.workspaceFolders[0].uri.path;
-      bazelExecutable = bazelExecutable.replace(
-        "${workspaceFolder}", wspath);
-  }
-  return bazelExecutable;
+  return resolvePath(bazelExecutable);
 }

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -26,9 +26,14 @@ export function getDefaultBazelExecutablePath(): string {
   // Try to retrieve the executable from VS Code's settings. If it's not set,
   // just use "bazel" as the default and get it from the system PATH.
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
-  const bazelExecutable = bazelConfig.get<string>("executable");
+  let bazelExecutable = bazelConfig.get<string>("executable");
   if (bazelExecutable.length === 0) {
     return "bazel";
+  }
+  if (vscode.workspace.workspaceFolders !== undefined) {
+      const wspath = vscode.workspace.workspaceFolders[0].uri.path;
+      bazelExecutable = bazelExecutable.replace(
+        "${workspaceFolder}", wspath);
   }
   return bazelExecutable;
 }


### PR DESCRIPTION
The vscode extension API does not automatically expand variables, which
makes it difficult to configure workspace-relative paths for the buildifier and bazel
tools. 
